### PR TITLE
Fix compilation on GCC 9.3.0

### DIFF
--- a/src/CppPluginSupport/src/MfxAttribute.cpp
+++ b/src/CppPluginSupport/src/MfxAttribute.cpp
@@ -1,6 +1,8 @@
 #include "MfxAttribute.h"
 #include "macros.h"
 
+#include <cstring>
+
 MfxAttribute::MfxAttribute(const MfxHost& host, OfxPropertySetHandle properties)
 	: MfxBase(host)
 	, m_properties(properties)

--- a/src/CppPluginSupport/src/MfxEffect.cpp
+++ b/src/CppPluginSupport/src/MfxEffect.cpp
@@ -3,6 +3,7 @@
 #include "macros.h"
 
 #include <iostream>
+#include <cstring>
 
 void MfxEffect::SetHost(OfxHost* host)
 {

--- a/src/CppPluginSupport/src/MfxParam.cpp
+++ b/src/CppPluginSupport/src/MfxParam.cpp
@@ -9,6 +9,7 @@ MfxParam<T>::MfxParam(const MfxHost& host, OfxParamHandle param)
 
 //-----------------------------------------------------------------------------
 
+template <>
 int MfxParam<int>::GetValue()
 {
 	int value = 0;
@@ -16,6 +17,7 @@ int MfxParam<int>::GetValue()
 	return value;
 }
 
+template <>
 int2 MfxParam<int2>::GetValue()
 {
 	int2 value = { 0, 0 };
@@ -23,6 +25,7 @@ int2 MfxParam<int2>::GetValue()
 	return value;
 }
 
+template <>
 int3 MfxParam<int3>::GetValue()
 {
 	int3 value = { 0, 0, 0 };
@@ -30,6 +33,7 @@ int3 MfxParam<int3>::GetValue()
 	return value;
 }
 
+template <>
 double MfxParam<double>::GetValue()
 {
 	double value = 0;
@@ -37,6 +41,7 @@ double MfxParam<double>::GetValue()
 	return value;
 }
 
+template <>
 double2 MfxParam<double2>::GetValue()
 {
 	double2 value = { 0, 0 };
@@ -44,6 +49,7 @@ double2 MfxParam<double2>::GetValue()
 	return value;
 }
 
+template <>
 double3 MfxParam<double3>::GetValue()
 {
 	double3 value = { 0, 0, 0 };
@@ -51,6 +57,7 @@ double3 MfxParam<double3>::GetValue()
 	return value;
 }
 
+template <>
 bool MfxParam<bool>::GetValue()
 {
 	bool value = 0;


### PR DESCRIPTION
Hi, I have successfully compiled the plugin on Ubuntu 20.04 LTS and tested it with OpenMeshEffectForBlender, with the same results as when using the released binaries on Windows, i.e. it works :)

A few cosmetic changes were necessary to make it compile with GCC, it's probably more strict than Visual Studio.